### PR TITLE
Bug Fix: Fix near-identical frames from erroneously being identified as identical

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ The CRK Eclair Discord Bot!
   
 https://eclair.community/add-bot
 
+https://discord.gg/r6ZQFcRUK7
+
 ## Features
 - Topping Optimization
 - Stat Math

--- a/topping_bot/optimize/reader.py
+++ b/topping_bot/optimize/reader.py
@@ -126,7 +126,7 @@ def extract_unique_frames(fp: Path):
     video = cv2.VideoCapture(str(fp))
 
     count = -1
-    last_frame = None
+    last_partial_frame = None
     success, frame = video.read()
     y, x, c = frame.shape
     while success:
@@ -137,15 +137,16 @@ def extract_unique_frames(fp: Path):
 
         # crop left half
         frame = frame[:, : x // 2]
+        partial_frame = frame[y // 2:-(y // 4)]
 
         # unique frame check
-        if last_frame is None:
-            new_y, new_x, new_c = frame.shape
+        if last_partial_frame is None:
+            new_y, new_x, new_c = partial_frame.shape
             threshold = new_y * new_x // 200
-            last_frame = frame
+            last_partial_frame = partial_frame
             yield frame
-        elif cv2.norm(last_frame, frame, cv2.NORM_L2) > threshold:
-            last_frame = frame
+        elif cv2.norm(last_partial_frame, partial_frame, cv2.NORM_L2) > threshold:
+            last_partial_frame = partial_frame
             yield frame
         success, frame = video.read()
 


### PR DESCRIPTION
![frame-1](https://github.com/wumphlett/Eclair/assets/57341657/f77634c8-a2a7-49af-9bf3-8510f641a523)
![frame-2](https://github.com/wumphlett/Eclair/assets/57341657/8f0bd098-ae8f-4c8f-ba1a-67fb0039028d)

Frames (usually with the same substats) that are nearly identical on the left side can be confused as identical and not submitted for topping data scraping.

By performing identical checks on only the part of the frame we're most likely interested in, we avoid missing toppings.