### PR TITLE
Feature: Add command to delete individual topping(s)

### DIFF
--- a/topping_bot/cogs/cookies.py
+++ b/topping_bot/cogs/cookies.py
@@ -289,7 +289,17 @@ class Cookies(Cog, description="Optimize your cookies' toppings"):
                     json.dump(data, f, indent=4)
 
         cookie_img.unlink(missing_ok=True)
-        await RemoveToppingsMenu(timeout=600).start(ctx, user, toppings=optimizer.inventory, fp=topping_fp)
+
+        embed_options = {
+            "title": "Remove Used Toppings?",
+            "description": "Would you like to remove the used toppings from your inventory?"
+        }
+        inner_embed_options = {
+            "title": "CONFIRM REMOVE USED TOPPINGS",
+            "description":  "ARE YOU SURE YOU WANT TO REMOVE THE USED TOPPINGS FROM YOUR INVENTORY?"
+        }
+
+        await RemoveToppingsMenu(timeout=600).start(ctx, user, toppings=optimizer.inventory, fp=topping_fp, embed_options=embed_options, inner_embed_options=inner_embed_options)
 
     @commands.command(brief="Stop", description="Stop a running optimization")
     async def stop(self, ctx):

--- a/topping_bot/cogs/inventory.py
+++ b/topping_bot/cogs/inventory.py
@@ -364,7 +364,20 @@ class Inventory(Cog, description="View and update your topping inventory"):
         temp_msg = await channel.send(file=discord.File(image, filename=image.name))
         embed_image = [attachment.url for attachment in temp_msg.attachments][0]
 
-        await RemoveToppingsMenu(timeout=600).start(ctx, ctx.message.author, toppings=remaining_toppings, fp=fp, embed_image=embed_image)
+        embed_options = {
+            "title": "Delete Individual Toppings",
+            "description": "Would you like to remove these toppings from your inventory?",
+            "image": embed_image,
+            "thumbnail": False
+        }
+        inner_embed_options = {
+            "title": "CONFIRM REMOVE TOPPINGS",
+            "description":  "ARE YOU SURE YOU WANT TO REMOVE THESE TOPPINGS FROM YOUR INVENTORY?",
+            "image": embed_image,
+            "thumbnail": False
+        }
+
+        await RemoveToppingsMenu(timeout=600).start(ctx, ctx.message.author, toppings=remaining_toppings, fp=fp, embed_options=embed_options, inner_embed_options=inner_embed_options)
 
     @commands.command(checks=[admin_only], brief="Debug video", description="Debug video")
     async def debug(self, ctx, video_id, verbose=False):

--- a/topping_bot/cogs/inventory.py
+++ b/topping_bot/cogs/inventory.py
@@ -22,8 +22,8 @@ from topping_bot.util.const import CONFIG, DATA_PATH, DEBUG_PATH, TMP_PATH
 from topping_bot.util.cpu import full_extraction
 from topping_bot.util.image import toppings_to_images
 from topping_bot.util.parallel import RUNNING_CPU_TASK, SEMAPHORE
-from topping_bot.ui.common import Paginator
-
+from topping_bot.util.converters import IndicesConverter
+from topping_bot.ui.common import Paginator, RemoveToppingsMenu
 
 class Inventory(Cog, description="View and update your topping inventory"):
     def __init__(self, bot):
@@ -95,7 +95,7 @@ class Inventory(Cog, description="View and update your topping inventory"):
             msgs = []
             embed_images = []
 
-            images = toppings_to_images(toppings, ctx.message.author.id)
+            images = toppings_to_images(toppings, ctx.message.author.id, show_index=True)
 
             for subset in (images[i: i + 10] for i in range(0, len(images), 10)):
                 msg = await channel.send(files=[discord.File(image, filename=image.name) for image in subset])
@@ -293,6 +293,104 @@ class Inventory(Cog, description="View and update your topping inventory"):
                 "Use !tutorial to learn more",
             ],
         )
+
+
+    @inv.command(aliases=["dt"], brief="Delete topping", description="Delete topping(s) from inventory by index")
+    async def deletetopping(self, ctx, indices=parameter(description="indices of toppings in inventory separated by space (up to 25 toppings)", default=[], converter=IndicesConverter[int])):    
+        if not 1 <= len(indices) <= 25:
+            await send_msg(
+                ctx,
+                title="Err: Unexpected Number of Toppings",
+                description=[
+                    "You have specified # of toppings outside of the expected range.",
+                    "Please only include between 1 to 25 toppings.",
+                    "",
+                    "E.g. to delete first 3 toppings in inventory:",
+                    "!inv deletetopping 0 1 2",
+                ],
+            )
+            return
+
+        fp = DATA_PATH / f"{ctx.message.author.id}.csv"
+
+        if not fp.exists():
+            await send_msg(
+                ctx,
+                title="Err: No Topping Inventory",
+                description=[
+                    "You have not submitted a topping video.",
+                    "Please use !updateinv <video> to update your inventory.",
+                    "Use !tutorial to learn more.",
+                ],
+            )
+            return
+
+        toppings = read_toppings(fp)
+
+        if not toppings:
+            await send_msg(
+                ctx,
+                title="Err: No Topping Inventory",
+                description=[
+                    "Your toppings on file are empty.",
+                    "Please use !updateinv <video> to update your inventory.",
+                    "Use !tutorial to learn more.",
+                ],
+            )
+            return
+        
+        invalid_indices = list(filter(lambda i: not 0 <= i <= len(toppings) - 1, indices))
+
+        if invalid_indices:
+            await send_msg(
+                ctx,
+                title="Err: Index Out of Range",
+                description=[
+                    "At least one of the specified toppings is outside the expected range.",
+                    "Please check that you provided valid indices.",
+                    "",
+                    "E.g. to delete first 3 toppings in inventory:",
+                    "!inv deletetopping 0 1 2",
+                ],
+            )
+            return
+
+        msg = None
+        if SEMAPHORE.locked():
+            tqdm.write(
+                f"{datetime.now().isoformat(sep=' ', timespec='seconds')} : {ctx.message.author} queued !deletetopping"
+            )
+            msg = await send_msg(
+                ctx,
+                title="Delete Toppings Queued",
+                description=[
+                    f"Your request to !deletetopping has been queued",
+                    "",
+                    "This will start automatically when ready",
+                ],
+            )
+
+        RUNNING_CPU_TASK[ctx.message.author.id] = None
+        async with SEMAPHORE:
+            tqdm.write(
+                f"{datetime.now().isoformat(sep=' ', timespec='seconds')} : {ctx.message.author} began !deletetopping"
+            )
+            if msg is None:
+                msg = await send_msg(ctx, title="Deleting toppings...", description=["Please wait"])
+            else:
+                await edit_msg(msg, title="Deleting toppings...", description=["Please wait"])
+            
+            toppings_to_remove =  [row for index, row in enumerate(toppings) if index in indices]
+            remaining_toppings = [row for index, row in enumerate(toppings) if index not in indices]
+
+            # generate preview image
+            channel = self.bot.get_channel(CONFIG["community"]["img-dump"])
+            image = toppings_to_images(toppings_to_remove, ctx.message.author, show_index=False)[0]
+            temp_msg = await channel.send(file=discord.File(image, filename=image.name))
+            embed_image = [attachment.url for attachment in temp_msg.attachments][0]
+
+            await RemoveToppingsMenu(timeout=600).start(ctx, ctx.message.author, toppings=remaining_toppings, fp=fp, embed_image=embed_image)
+        RUNNING_CPU_TASK.pop(ctx.message.author.id)
 
     @commands.command(checks=[admin_only], brief="Debug video", description="Debug video")
     async def debug(self, ctx, video_id, verbose=False):

--- a/topping_bot/cogs/inventory.py
+++ b/topping_bot/cogs/inventory.py
@@ -295,7 +295,7 @@ class Inventory(Cog, description="View and update your topping inventory"):
         )
 
 
-    @inv.command(aliases=["dt"], brief="Delete topping", description="Delete topping(s) from inventory by index")
+    @inv.command(aliases=["delt"], brief="Delete topping", description="Delete topping(s) from inventory by index")
     async def deletetopping(self, ctx, indices=parameter(description="indices of toppings in inventory separated by space (up to 25 toppings)", default=[], converter=IndicesConverter[int])):    
         if not 1 <= len(indices) <= 25:
             await send_msg(
@@ -305,8 +305,7 @@ class Inventory(Cog, description="View and update your topping inventory"):
                     "You have specified # of toppings outside of the expected range.",
                     "Please only include between 1 to 25 toppings.",
                     "",
-                    "E.g. to delete first 3 toppings in inventory:",
-                    "!inv deletetopping 0 1 2",
+                    "Use !help inv deletetopping to learn more."
                 ],
             )
             return
@@ -349,8 +348,9 @@ class Inventory(Cog, description="View and update your topping inventory"):
                     "At least one of the specified toppings is outside the expected range.",
                     "Please check that you provided valid indices.",
                     "",
-                    "E.g. to delete first 3 toppings in inventory:",
-                    "!inv deletetopping 0 1 2",
+                    f"The invalid indices: {', '.join(str(i) for i in invalid_indices)}.",
+                    "",
+                    "Use !help inv deletetopping to learn more."
                 ],
             )
             return

--- a/topping_bot/ui/common.py
+++ b/topping_bot/ui/common.py
@@ -161,7 +161,7 @@ class RemoveToppingsMenu(View):
         super().__init__(timeout=timeout)
         self.inner = inner
 
-    async def start(self, ctx, member, toppings: List[Topping], fp: Path):
+    async def start(self, ctx, member, toppings: List[Topping], fp: Path, embed_image=None):
         if isinstance(ctx, discord.Interaction):
             ctx = await commands.Context.from_interaction(ctx)
 
@@ -170,6 +170,7 @@ class RemoveToppingsMenu(View):
 
         self.toppings = toppings
         self.fp = fp
+        self.embed_image = embed_image
 
         self.yes_button = Button(label="Remove", style=ButtonStyle.danger)
         self.yes_button.callback = self.yes_button_callback
@@ -186,11 +187,19 @@ class RemoveToppingsMenu(View):
             title = "Remove Toppings?"
             desc = "Would you like to remove the used toppings from your inventory?"
 
+        embed_params = {
+            "title": title,
+            "description": desc, 
+        }
+
+        if self.embed_image:
+            embed_params.update({
+                "image": self.embed_image,
+                "thumbnail": False
+            })
+
         self.message = await ctx.reply(
-            embed=await new_embed(
-                title=title,
-                description=desc,
-            ),
+            embed=await new_embed(**embed_params),
             ephemeral=True,
             view=self,
         )
@@ -200,7 +209,7 @@ class RemoveToppingsMenu(View):
             self.stop()
             await self.cleanup()
             await RemoveToppingsMenu(timeout=self.timeout, inner=True).start(
-                self.ctx, self.member, toppings=self.toppings, fp=self.fp
+                self.ctx, self.member, toppings=self.toppings, fp=self.fp, embed_image=self.embed_image
             )
         if self.inner:
             write_toppings(self.toppings, self.fp)

--- a/topping_bot/util/converters.py
+++ b/topping_bot/util/converters.py
@@ -1,0 +1,7 @@
+from discord.ext.commands import Greedy
+
+# custom converter since Greedy has no __name__ attribute, causing issues with documentation
+class IndicesConverter(Greedy):
+    def __init__(self, converter):
+        self.__name__ = "indices" 
+        self.converter = converter

--- a/topping_bot/util/converters.py
+++ b/topping_bot/util/converters.py
@@ -3,5 +3,5 @@ from discord.ext.commands import Greedy
 # custom converter since Greedy has no __name__ attribute, causing issues with documentation
 class IndicesConverter(Greedy):
     def __init__(self, converter):
-        self.__name__ = "indices" 
+        self.__name__ = "List[int]" 
         self.converter = converter

--- a/topping_bot/util/help.py
+++ b/topping_bot/util/help.py
@@ -54,6 +54,7 @@ ORDERING = {
         "inv",
         "inv add",
         "inv delete",
+        "inv deletetopping",
         "updateinv",
         "appendinv",
         "count",

--- a/topping_bot/util/image.py
+++ b/topping_bot/util/image.py
@@ -138,7 +138,7 @@ def image_midline(image):
     return round(np.sum(dx * np.arange(X)))
 
 
-def toppings_to_images(toppings: List[Topping], user_id):
+def toppings_to_images(toppings: List[Topping], user_id, show_index=False):
     images = []
 
     for i, subset in enumerate(toppings[i : i + 25] for i in range(0, len(toppings), 25)):
@@ -180,6 +180,14 @@ def toppings_to_images(toppings: List[Topping], user_id):
                     stroke_fill="rgb(0, 0, 0)",
                     stroke_width=2,
                     align="right",
+                )
+                show_index and draw.text(
+                    (x - 10, y + 160), 
+                    str(i * 25 + y_mult * 5 + x_mult),
+                    font=STATIC["font"], 
+                    fill="rgb(255, 255, 0)",
+                    stroke_fill="rgb(0, 0, 0)",
+                    stroke_width=2,
                 )
 
         image.save(fp)


### PR DESCRIPTION
# Description
This PR adds a new command called `!inv deletetopping` which allows user to delete individual topping(s) from their inventory by index. User no longer needs to reset their entire inventory when accidentally adding toppings or bugged resonants.

# Solution Discussion
`!inv deletetopping [indices]` where indices param is a list of space separated integers.

**Param expectations:**
- must provide between 1 and 25 indices
  - upperbound because `RemoveToppingsMenu` does not immediately support pagination, so images must fit in a single image
  - also individual deletion should be an uncommon operation. Seems unlikely a user will frequently need to delete more than 25 toppings
  - supporting pagination could be a future enhancement
- each index must be in valid range 0 to max index

**Modified existing components:**
- `RemoveToppingsMenu` now supports embed image (optional)
- `toppings_to_images()` now supports showing indices for the toppings (optional)



# Screenshots / Videos

> Demo

https://github.com/wumphlett/Eclair/assets/22565040/6639d221-1932-4084-bb75-1157cb130702

> Error 1 - invalid # toppings
![image](https://github.com/wumphlett/Eclair/assets/22565040/8acfa73e-7298-44a8-ad03-fba5f3b1d1c8)

> Error 2 - indices outside range
![image](https://github.com/wumphlett/Eclair/assets/22565040/21c13145-3b28-4250-bd1c-4dcfd716bb34)

> Help cmd
![image](https://github.com/wumphlett/Eclair/assets/22565040/c61dccf1-e98c-4dbd-8e37-edfc38eedcb8)
![image](https://github.com/wumphlett/Eclair/assets/22565040/7bdbf6ca-06ef-4cec-826e-4f947c5b09d4)

# Risk
Minor risk. Some modification to existing workflows like `!optimize` and `!inv`