### PR TITLE
Bug Fix: Alter multiprocessing logic to be more resilient

### DIFF
--- a/topping_bot/cogs/community.py
+++ b/topping_bot/cogs/community.py
@@ -95,7 +95,7 @@ class Community(Cog, description="Helper commands available to all!"):
                 "https://eclair.community/add-bot",
             ],
             wrap=False,
-            footer=f"admin: {(await ctx.bot.application_info()).owner}",
+            footer=f"admin: @{(await ctx.bot.application_info()).owner}",
         )
 
     @cooldown(1, 1, BucketType.user)

--- a/topping_bot/optimize/optimize.py
+++ b/topping_bot/optimize/optimize.py
@@ -38,6 +38,9 @@ class Optimizer:
         self.inventory = [topping for topping in self.inventory if topping not in self.solution.toppings]
         self.cookies[name] = self.solution
 
+    def set_solution(self, indices: List[int]):
+        self.solution = ToppingSet([self.inventory[i] for i in indices])
+
     def solve(self, reqs: Requirements):
         """Solves a cookies needed toppings given a set of requirements"""
         self.reqs = reqs


### PR DESCRIPTION
Multiprocessing for CPU-bound tasks was always shaky to do it in a way that played nice with asyncio. This adjusts how it's done, and attaches processes to user ids for running CPU task checks. Doing this allows for immediate cancelation of processes that exceed timeout and direct querying of process alive status when determining if a user is already running a task.