### PR TITLE
Enhancement: Add cookie avatar in the optimize result image

### DIFF
--- a/topping_bot/cogs/cookies.py
+++ b/topping_bot/cogs/cookies.py
@@ -258,7 +258,7 @@ class Cookies(Cog, description="Optimize your cookies' toppings"):
                 optimizer.reqs = cookie
                 optimizer.select(cookie.name)
 
-                cookie_img = topping_set_to_image(optimizer.solution, ctx.message.author.id)
+                cookie_img = topping_set_to_image(optimizer.solution, ctx.message.author.id, name=cookie.name)
 
                 name = "".join(char for char in cookie.name if char.isalnum())
                 image = discord.File(cookie_img, filename=f"{name}.png")

--- a/topping_bot/util/image.py
+++ b/topping_bot/util/image.py
@@ -186,8 +186,7 @@ def toppings_to_images(toppings: List[Topping], user_id):
         images.append(fp)
     return images
 
-
-def topping_set_to_image(topping_set: ToppingSet, user_id):
+def topping_set_to_image(topping_set: ToppingSet, user_id, name: str=None):
     fp = TMP_PATH / f"{user_id}.png"
 
     image = Image.new("RGBA", (1080, 1080), "rgb(3, 5, 9)")
@@ -328,6 +327,13 @@ def topping_set_to_image(topping_set: ToppingSet, user_id):
             stroke_width=2,
             anchor="ma",
         )
+
+    if name:
+        cookie = Cookie.get(name)
+        
+    if cookie:
+        card = Image.open(cookie.card).resize((125, 125))
+        image.paste(card, (25, 25))
 
     image.save(fp)
     return fp


### PR DESCRIPTION
# Description
This PR adds a mini cookie card to the optimize result image.
It addresses suggestion raised by user Ducc https://discord.com/channels/1090949984356159538/1133968768654114867

# Screenshot / Video

https://github.com/wumphlett/Eclair/assets/22565040/39708275-c6d0-4814-9ab4-d50cc2f285bc

> output
![image](https://github.com/wumphlett/Eclair/assets/22565040/e98ed210-42c2-40a5-ac6f-947211791506)
