### PR TITLE
Bug Fix: entropy calculation when crit exceeds 100%

### DIFF
--- a/topping_bot/optimize/objectives.py
+++ b/topping_bot/optimize/objectives.py
@@ -148,7 +148,10 @@ class EDMG(Special):
 
     def fancy_value(self, topping_set: ToppingSet):
         crit = min(Decimal(1), topping_set.value(Type.CRIT) / Decimal(100) + self.base_crit)
-        rng = Decimal(-float(crit) * math.log2(crit) - float(1 - crit) * math.log2(1 - crit)).quantize(Decimal(".001"))
+        if crit == Decimal(1): 
+            rng = Decimal(0).quantize(Decimal(".001"))
+        else:
+            rng = Decimal(-float(crit) * math.log2(crit) - float(1 - crit) * math.log2(1 - crit)).quantize(Decimal(".001"))
         return {Type.E_DMG: self.value(topping_set) * 100, Type.RNG: rng * 100}
 
 


### PR DESCRIPTION
Solves would fail if `crit == 1`.
The following part of the entropy formula tried to take log of 0 resulting in math domain error. `math.log2(1 - crit))` 

I noticed it happening with rockstar cookie solves.